### PR TITLE
feat: PD-6312 apply roles to all subscriptions in AD

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,25 @@ to your Azure account using the scripts in this repository to apply these roles 
 
 This script creates a new Custom role within the Active Directory that the App Registration resides in.
 
-This new Custom role along with the built-in "Reader" role is applied to the subscription that is specified.
+This new Custom role along with the built-in "Reader" role is applied to either all the Subscriptions in the
+Active Directory or just the subscription that is specified.
+
+## Usage
+
+```bash
+bash apply-roles --application-id <App registration client id> [--subscription-id <subscription id>]
+```
+
+`--application-id`
+
+The Application (client) ID of the App registration that Cloud One Conformity will be given access to.
+
+`--subscription-id` _Optional_
+
+The id of the Subscription to apply the role and permissions to.
+
+If not supplied then the access roles will be added to all the Subscriptions in the Active Directory the App
+Registration has been created within.
 
 ## Running the script
 ### Azure Portal Cloud Shell (Bash)
@@ -18,33 +36,29 @@ This new Custom role along with the built-in "Reader" role is applied to the sub
 3. Run the following
 ```bash
 curl -s https://raw.githubusercontent.com/cloudconformity/azure-onboarding-scripts/master/apply-roles | bash /dev/stdin \
-    --application-id <App registration client id> \
-    --subscription-id <Subscription id>
+    --application-id <App registration client id>
 ```
-`<App client id>` is the Application (client) ID of the App registration that Cloud One Conformity will be given access to
-`<Subscription id>` is the id of the Subscription to apply the role and permissions to.
 
 ### On local terminal
 
 #### Pre-requisites
-1. Bash version >= 4.
-2. [jq](https://stedolan.github.io/jq/).
+1. Bash version >= 4
+2. [jq](https://stedolan.github.io/jq/)
 
-_Note: Both of these are available by default in the Azure Cloud Shell_.
+_Note: Both of these are available by default in the Azure Cloud Shell._
 
 #### Running the script
 1. Install Azure CLI ([Installation instructions](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest)).
-1. Clone the Github repository or copy all the files to your local machine.
 2. Log into your Azure account using `az login`.
-3. Locate the id of the App Registration that the custom role is to be applied to.
-4. In the same directory as the bash script run.
+3. Clone the Github repository or copy all the files to your local machine.
+4. Make the following modifications to the bash script
+   1. Change the value of the `GITHUB_URI` variable to `"."`.
+   2. Rename all reference to the `--template-uri` parameter to `--template-file`.
+5. Locate the id of the App Registration that the custom role is to be applied to.
+6. In the same directory as the bash script run.
 ```bash
-bash apply-roles \
-    --application-id <App registration client id> \
-    --subscription-id <Subscription id>
+bash apply-roles --application-id <App registration client id>
 ```
-`<App client id>` is the Application (client) ID of the App registration that CloudOne Conformity will be given access to.
-`<Subscription id>` is the id of the Subscription to apply the role and permissions to.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ _Note: Both of these are available by default in the Azure Cloud Shell._
 bash apply-roles --application-id <App registration client id>
 ```
 
+## Known limitations
+
+1. _Doesn't gracefully handle subscriptions with no permissions to update_
+
+   When running the script against all subscriptions in the Active Directory if there is a subscription which the user running
+the script doesn't have permissions to apply the roles to, the script will fail. Any subscriptions that were processed before
+this subscription will have the roles applied.
+
 ## Contributing
 
 The code style of the shell script follows the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)

--- a/apply-roles
+++ b/apply-roles
@@ -9,45 +9,88 @@ readonly BRANCH="master"
 readonly GITHUB_URI="https://raw.githubusercontent.com/cloudconformity/azure-onboarding-scripts/${BRANCH}"
 readonly CUSTOM_ROLE_NAME="Custom Role - Cloud One Conformity"
 
-if [ ! -x "$(command -v jq)" ]; then
-  echo "Error: jq is required to be installed to run this script" >&2
-  exit 1
-fi
+apply_roles_to_subscription() {
+  local subscription_id="${1}"
 
-application_id=
-subscription_id=
+  echo "Checking custom role assignment for subscription - ${subscription_id}"
+  is_custom_role_assigned=$(az role assignment list \
+    --role "${reader_role_id}" \
+    --subscription="${subscription_id}" \
+    --assignee "${principal_id}" \
+    --query "[0].id" \
+    --output tsv)
 
-# capture CLI arguments
-while [ "${1}" != "" ]; do
-  case "${1}" in
-  -a | --application-id)
+  if [[ -z "${is_custom_role_assigned}" ]] || [[ "${is_custom_role_assigned}" == "null" ]]; then
+    echo "Assigning custom role to service principal"
+    az deployment sub create \
+      --location eastus \
+      --subscription="${subscription_id}" \
+      --template-uri "${GITHUB_URI}/roleAssignment/customRoleDeploy.json" \
+      --parameters \
+      principalId="${principal_id}" \
+      roleDefinitionId="${role_definition_id}" \
+      subscriptionId="${subscription_id}"
+    echo "Custom role assigned to service principal"
+  fi
+
+  echo "Custom role assigned"
+
+  echo "Checking built-in \"Reader\" role assignment"
+  # retrieve built-in "Reader" role
+  reader_role_id=$(az role definition list --name Reader --query "[0].name" --output tsv)
+  # check if role is already assigned
+  is_reader_role_assigned=$(az role assignment list \
+    --role "${reader_role_id}" \
+    --subscription="${subscription_id}" \
+    --assignee "${principal_id}" \
+    --query "[0].id" \
+    --output tsv)
+
+  if [[ -z "${is_reader_role_assigned}" ]] || [[ "${is_reader_role_assigned}" == "null" ]]; then
+    echo "Assigning built-in \"Reader\" role to service principal"
+    az deployment sub create \
+      --location eastus \
+      --subscription="${subscription_id}" \
+      --template-uri "${GITHUB_URI}/roleAssignment/readerRoleDeploy.json" \
+      --parameters \
+      principalId="${principal_id}" \
+      roleDefinitionId="${reader_role_id}"
+  fi
+
+  echo "\"Reader\" role assigned"
+}
+
+main() {
+  local application_id
+  local subscription_id
+
+  if [ ! -x "$(command -v jq)" ]; then
+    echo "Error: jq is required to be installed to run this script" >&2
+    exit 1
+  fi
+
+  # capture CLI arguments
+  while [ "${1}" != "" ]; do
+    case "${1}" in
+    -a | --application-id)
+      shift
+      application_id="${1}"
+      ;;
+    -s | --subscription-id)
+      shift
+      subscription_id="${1}"
+      ;;
+    esac
     shift
-    application_id="${1}"
-    ;;
-  -s | --subscription-id)
-    shift
-    subscription_id="${1}"
-    ;;
-  esac
-  shift
-done
+  done
 
-if [[ -z "${application_id}" ]]; then
-  echo "Error: --application-id argument is required" >&2
-  exit 1
-fi
+  if [[ -z "${application_id}" ]]; then
+    echo "Error: --application-id argument is required" >&2
+    exit 1
+  fi
 
-if [[ -z "${subscription_id}" ]]; then
-  echo "Error: --subscription-id argument is required" >&2
-  exit 1
-fi
-
-echo "Searching for existing custom \"${CUSTOM_ROLE_NAME}\" role definition"
-role_definition_id=$(az role definition list --name "${CUSTOM_ROLE_NAME}" --query "[0].name" --output tsv)
-
-if [[ -z "${role_definition_id}" ]] || [[ "${role_definition_id}" == "null" ]]; then
-  echo "Custom role definition not found"
-  echo "Creating custom \"${CUSTOM_ROLE_NAME}\" role definition"
+  echo "Searching for existing custom \"${CUSTOM_ROLE_NAME}\" role definition"
+  role_definition_id=$(az role definition list --name "${CUSTOM_ROLE_NAME}" --query "[0].name" --output tsv)
 
   # retrieving Tenant id for Active Directory
   tenant_id=$(az ad sp show --id "${application_id}" --query "appOwnerTenantId" --output tsv)
@@ -55,84 +98,52 @@ if [[ -z "${role_definition_id}" ]] || [[ "${role_definition_id}" == "null" ]]; 
   # retrieve list of all subscriptions in the tenant and convert into a bash array
   readarray -t subscription_ids < <(az account list --query "[?tenantId=='${tenant_id}'].id" --output tsv)
 
-  # generate set of assignable scopes for the custom role
-  for subscription in "${subscription_ids[@]}"; do
-    # prefix subscription id with "/subscriptions/" as is needed when added to the assignable scopes
-    prefixed_ids=("${prefixed_ids[@]}" "/subscriptions/${subscription}")
-  done
-
-  # convert bash array into a JSON array so can be passed to role creation
-  prefixed_subscription_ids=$(printf '%s\n' "${prefixed_ids[@]}" | jq -R . | jq -s .)
-
-  az deployment sub create \
-    --location eastus \
-    --template-uri "${GITHUB_URI}/roleDefinition/create/deploy.json" \
-    --parameters \
-    "${GITHUB_URI}/roleDefinition/create/deploy.parameters.json" \
-    roleName="${CUSTOM_ROLE_NAME}" \
-    subscriptionIds="${prefixed_subscription_ids}"
-  echo "Custom role \"${CUSTOM_ROLE_NAME}\" created"
-  echo "Waiting for role to be searchable..."
-  sleep 10
-
-  role_definition_id=$(az role definition list --name "${CUSTOM_ROLE_NAME}" --query "[0].name" --output tsv)
-
   if [[ -z "${role_definition_id}" ]] || [[ "${role_definition_id}" == "null" ]]; then
-    echo "Error: Custom role creation failed"
-    exit 1
+    echo "Custom role definition not found"
+    echo "Creating custom \"${CUSTOM_ROLE_NAME}\" role definition"
+
+    # generate set of assignable scopes for the custom role
+    for subscription in "${subscription_ids[@]}"; do
+      # prefix subscription id with "/subscriptions/" as is needed when added to the assignable scopes
+      prefixed_ids=("${prefixed_ids[@]}" "/subscriptions/${subscription}")
+    done
+
+    # convert bash array into a JSON array so can be passed to role creation
+    prefixed_subscription_ids=$(printf '%s\n' "${prefixed_ids[@]}" | jq -R . | jq -s .)
+
+    az deployment sub create \
+      --location eastus \
+      --template-uri "${GITHUB_URI}/roleDefinition/create/deploy.json" \
+      --parameters \
+      "${GITHUB_URI}/roleDefinition/create/deploy.parameters.json" \
+      roleName="${CUSTOM_ROLE_NAME}" \
+      subscriptionIds="${prefixed_subscription_ids}"
+    echo "Custom role \"${CUSTOM_ROLE_NAME}\" created"
+    echo "Waiting for role to be searchable..."
+    sleep 10
+
+    role_definition_id=$(az role definition list --name "${CUSTOM_ROLE_NAME}" --query "[0].name" --output tsv)
+
+    if [[ -z "${role_definition_id}" ]] || [[ "${role_definition_id}" == "null" ]]; then
+      echo "Error: Custom role creation failed"
+      exit 1
+    fi
+  else
+    echo "Existing custom \"${CUSTOM_ROLE_NAME}\" role definition found"
   fi
-else
-  echo "Existing custom \"${CUSTOM_ROLE_NAME}\" role definition found"
-fi
 
-echo "Custom role id: ${role_definition_id}"
+  echo "Custom role id: ${role_definition_id}"
 
-# retrieve Service principal id
-principal_id=$(az ad sp show --id "${application_id}" --query "objectId" --output tsv)
+  # retrieve Service principal id
+  principal_id=$(az ad sp show --id "${application_id}" --query "objectId" --output tsv)
 
-echo "Checking custom role assignment"
-is_custom_role_assigned=$(az role assignment list \
-  --role "${reader_role_id}" \
-  --subscription="${subscription_id}" \
-  --assignee "${principal_id}" \
-  --query "[0].id" \
-  --output tsv)
+  if [[ -n "${subscription_id}" ]]; then
+    apply_roles_to_subscription "${subscription_id}"
+  else
+    for subscription in "${subscription_ids[@]}"; do
+      apply_roles_to_subscription "${subscription}"
+    done
+  fi
+}
 
-if [[ -z "${is_custom_role_assigned}" ]] || [[ "${is_custom_role_assigned}" == "null" ]]; then
-  echo "Assigning custom role to service principal"
-  az deployment sub create \
-    --location eastus \
-    --subscription="${subscription_id}" \
-    --template-uri "${GITHUB_URI}/roleAssignment/customRoleDeploy.json" \
-    --parameters \
-    principalId="${principal_id}" \
-    roleDefinitionId="${role_definition_id}" \
-    subscriptionId="${subscription_id}"
-  echo "Custom role assigned to service principal"
-fi
-
-echo "Custom role assigned"
-
-echo "Checking built-in \"Reader\" role assignment"
-# retrieve built-in "Reader" role
-reader_role_id=$(az role definition list --name Reader --query "[0].name" --output tsv)
-# check if role is already assigned
-is_reader_role_assigned=$(az role assignment list \
-  --role "${reader_role_id}" \
-  --subscription="${subscription_id}" \
-  --assignee "${principal_id}" \
-  --query "[0].id" \
-  --output tsv)
-
-if [[ -z "${is_reader_role_assigned}" ]] || [[ "${is_reader_role_assigned}" == "null" ]]; then
-  echo "Assigning built-in \"Reader\" role to service principal"
-  az deployment sub create \
-    --location eastus \
-    --subscription="${subscription_id}" \
-    --template-uri "${GITHUB_URI}/roleAssignment/readerRoleDeploy.json" \
-    --parameters \
-    principalId="${principal_id}" \
-    roleDefinitionId="${reader_role_id}"
-fi
-
-echo "\"Reader\" role assigned"
+main "$@"

--- a/apply-roles
+++ b/apply-roles
@@ -9,6 +9,11 @@ readonly BRANCH="master"
 readonly GITHUB_URI="https://raw.githubusercontent.com/cloudconformity/azure-onboarding-scripts/${BRANCH}"
 readonly CUSTOM_ROLE_NAME="Custom Role - Cloud One Conformity"
 
+if [ ! -x "$(command -v jq)" ]; then
+  echo "Error: jq is required to be installed to run this script" >&2
+  exit 1
+fi
+
 application_id=
 subscription_id=
 


### PR DESCRIPTION
Now if the `--subscription-id` param is not provided then the script will apply the roles to all the subscriptions in the Active Directory. However if a subscription id is supplied then it will only apply the roles to that subscription.

To do this the apply code was moved to an new function and the main code runner was put inside a `main` function as per the Google bash style guide