### PR TITLE
refactor: PD-7779 change code to remove reliance on a bash v4 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ curl -s https://raw.githubusercontent.com/cloudconformity/azure-onboarding-scrip
 ### On local terminal
 
 #### Pre-requisites
-1. Bash version >= 4
 2. [jq](https://stedolan.github.io/jq/)
 
-_Note: Both of these are available by default in the Azure Cloud Shell._
+_Note: This is available by default in the Azure Cloud Shell._
 
 #### Running the script
 1. Install Azure CLI ([Installation instructions](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest)).

--- a/apply-roles
+++ b/apply-roles
@@ -145,7 +145,11 @@ main() {
   tenant_id=$(az ad sp show --id "${application_id}" --query "appOwnerTenantId" --output tsv)
 
   # retrieve list of all subscriptions in the Active Directory and convert into a bash array
-  readarray -t subscription_ids_in_active_directory < <(az account list --query "[?tenantId=='${tenant_id}'].id" --output tsv)
+  subscription_ids_in_active_directory=()
+  # Bash v3 supported method of converting to an array ref: https://github.com/koalaman/shellcheck/wiki/SC2207
+  while IFS='' read -r line; do
+    subscription_ids_in_active_directory+=("$line");
+  done < <(az account list --query "[?tenantId=='${tenant_id}'].id" --output tsv)
 
   if [[ -z "${custom_role_definition_id}" ]] || [[ "${custom_role_definition_id}" == "null" ]]; then
     echo "Custom role definition not found"


### PR DESCRIPTION
`readarray` is only available in Bash 4+ but as Macs come preinstalled only with Bash 3 some feedback from the SE team was that it wasn't reasonable to have a pre-requisite of needing to be on Bash 4 to run the script.

This approach is much more complicated but will remove the pre-requisite.