### PR TITLE
impr: PD-12399 Remove Azure AD Graph permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,26 +19,5 @@
         "type": "Role"
       }
     ]
-  },
-  {
-    "resourceAppId": "00000002-0000-0000-c000-000000000000",
-    "resourceAccess": [
-      {
-        "id": "5778995a-e1bf-45b8-affa-663a9f3f4d04",
-        "type": "Scope"
-      },
-      {
-        "id": "c582532d-9d9e-43bd-a97c-2667a28ce295",
-        "type": "Scope"
-      },
-      {
-        "id": "311a71cc-e848-46a1-bdf8-97ff7156d8e6",
-        "type": "Scope"
-      },
-      {
-        "id": "5778995a-e1bf-45b8-affa-663a9f3f4d04",
-        "type": "Role"
-      }
-    ]
   }
 ]


### PR DESCRIPTION
### Issue Link:

PD-12399

### What does it do?

Remove Azure AD Graph permissions

Delegated permissions
- Directory.Read.All
- User.Read
- User.Read.All

Application permissions
- Directory.Read.All

#### Checklist

- [x] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] I will merge without squashing: All commits conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] README update

---

#### Notes to reviewers

- Azure Active Directory Graph appId: `00000002-0000-0000-c000-000000000000`
<img width="742" alt="image" src="https://user-images.githubusercontent.com/94429197/188362656-53047991-c18b-4f9f-8567-c8902639cb46.png">

- Directory.Read.All id: `5778995a-e1bf-45b8-affa-663a9f3f4d04`
![image](https://user-images.githubusercontent.com/94429197/188363272-9932f327-f698-4886-a832-6364cceed988.png)

- User.Read id: `311a71cc-e848-46a1-bdf8-97ff7156d8e6`
![image](https://user-images.githubusercontent.com/94429197/188363453-ece5bcd8-2f24-470f-877d-fc9274482da4.png)

- User.Read.All id: `c582532d-9d9e-43bd-a97c-2667a28ce295`
![image](https://user-images.githubusercontent.com/94429197/188363378-0f783676-5a70-4c6d-9ed7-3a54328c1e4f.png)