### PR TITLE
impr: CPS-1259 Remove unnecessary permission

### DIFF
--- a/apply-roles
+++ b/apply-roles
@@ -119,8 +119,7 @@ generate_custom_role_definition() {
       \"Actions\": [ \
           \"Microsoft.AppConfiguration/configurationStores/ListKeyValue/action\", \
           \"Microsoft.Network/networkWatchers/queryFlowLogStatus/action\", \
-          \"Microsoft.Web/sites/config/list/Action\", \
-          \"Microsoft.Storage/storageAccounts/queueServices/queues/read\" \
+          \"Microsoft.Web/sites/config/list/Action\" \
       ], \
       \"DataActions\": [], \
       \"NotDataActions\": [], \


### PR DESCRIPTION
### Issue Link:

CPS-1259

### What does it do?

Update permissions list to remove `Microsoft.Storage/storageAccounts/queueServices/queues/read`.

#### Checklist


- [ ] BREAKING CHANGE - I have/intend to update all places where this package is used.
- [ ] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
- [x] I will merge without squashing: All commits conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] README update


---

#### Screenshots

Sandbox 1 - Before the updates: 
<img width="1493" alt="Screenshot 2024-04-29 at 2 51 49 pm" src="https://github.com/cloudconformity/azure-onboarding-scripts/assets/49009597/4a1411a2-ba16-4cf7-bf67-b9f91c3f336e">

Sandbox 1 - After the updates: 
<img width="1403" alt="Screenshot 2024-04-29 at 2 51 57 pm" src="https://github.com/cloudconformity/azure-onboarding-scripts/assets/49009597/27a1333a-3462-49ca-9f33-cf2f70d152a8">

Sandbox 2 - Before the updates: 
<img width="1425" alt="Screenshot 2024-04-29 at 2 52 06 pm" src="https://github.com/cloudconformity/azure-onboarding-scripts/assets/49009597/bc346dd0-15f2-42c2-9b67-7d7a99ade849">

Sandbox 2 - After the updates: 
<img width="1408" alt="Screenshot 2024-04-29 at 2 52 13 pm" src="https://github.com/cloudconformity/azure-onboarding-scripts/assets/49009597/16d4a86e-20c0-488c-9766-05046ddaaa42">

#### Related PR's

https://dsgithub.trendmicro.com/cloud-one-docs/docs-conformity/pull/734
https://adc.github.trendmicro.com/V1-Common/service-cloud-accounts/pull/1073

